### PR TITLE
chore :: 안드로이드 초기 빌드 설정

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.2.1" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_exe/router/router.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -5,22 +7,26 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // 윈도우 앱일 때만 windowManager 작동
+  if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+    await windowManager.ensureInitialized();
+    
+    WindowOptions windowOptions = const WindowOptions(
+      size: Size(1280, 800),
+      minimumSize: Size(1024, 768),
+      maximumSize: Size(1920, 1080),
+      center: true,
+      title: '전자동의시스템',
+    );
+
+    await windowManager.waitUntilReadyToShow(windowOptions, () async {
+      await windowManager.show();
+      await windowManager.focus();
+      await windowManager.setResizable(true);
+    });
+  }
   
-  await windowManager.ensureInitialized();
-
-  WindowOptions windowOptions = const WindowOptions(
-    size: Size(1280, 800),
-    minimumSize: Size(1024, 768),
-    maximumSize: Size(1920, 1080),
-    center: true,
-    title: '전자동의시스템',
-  );
-
-  await windowManager.waitUntilReadyToShow(windowOptions, () async {
-    await windowManager.show();
-    await windowManager.focus();
-    await windowManager.setResizable(true);
-  });
 
   runApp(
     const ProviderScope(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   # 날짜 선택
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.1
-  # intl: ^0.19.0
+  # intl: ^0.18.1
+  intl: ^0.19.0
   # 서버 통신
   dio: ^5.8.0+1
   # 저장소


### PR DESCRIPTION
- jdk와 AGP 버전 충돌 이슈로 인해 agp 버전을 8.2.1로 올림
- windowManager 플러그인이 andoid OS에서 동작하지 않는 이슈로, main단에서 실행 플랫폼 조건으로 분기처리
- intl 버전 변경